### PR TITLE
Add runtime class support

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ main:
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
+  runtimeClassName: ""
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -540,6 +541,7 @@ worker:
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
+  runtimeClassName: ""
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -725,10 +727,10 @@ webhook:
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
+  runtimeClassName: ""
   nodeSelector: {}
   tolerations: []
   affinity: {}
-
 #
 # User defined supplementary K8s manifests
 #

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.0.7
+version: 1.0.8
 appVersion: 1.85.1
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -48,6 +48,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "n8n.serviceAccountName" . }}
+      {{- with .Values.webhook.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.webhook.podSecurityContext | nindent 8 }}
       {{- if .Values.webhook.initContainers }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -46,6 +46,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "n8n.serviceAccountName" . }}
+      {{- with .Values.worker.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.worker.podSecurityContext | nindent 8 }}
       {{- if .Values.worker.initContainers }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "n8n.serviceAccountName" . }}
+      {{- with .Values.main.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.main.podSecurityContext | nindent 8 }}
       {{- if or .Values.main.initContainers }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -257,6 +257,9 @@ main:
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
+  # specify a runtimeClass for the pod
+  runtimeClassName: ""
+
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -441,6 +444,9 @@ worker:
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
+
+  # specify a runtimeClass for the worker pod
+  runtimeClassName: ""
 
   nodeSelector: {}
   tolerations: []
@@ -627,6 +633,7 @@ webhook:
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
+  runtimeClassName: ""
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## Summary
- allow specifying a runtimeClassName for all pods
- document runtimeClassName in README
- bump chart version to 1.0.8

## Testing
- `helm lint charts/n8n`

------
https://chatgpt.com/codex/tasks/task_e_684f59d18b2c832eb6eddc80d112468a